### PR TITLE
Add TwitterUtils file

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -45,6 +45,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.xatkit</groupId>
+            <artifactId>chat-platform-runtime</artifactId>
+            <version>2.0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
     <dependencyManagement>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -45,13 +45,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>com.xatkit</groupId>
-            <artifactId>chat-platform-runtime</artifactId>
-            <version>2.0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
-
     </dependencies>
 
     <dependencyManagement>

--- a/runtime/src/main/java/com/xatkit/plugins/twitter/TwitterUtils.java
+++ b/runtime/src/main/java/com/xatkit/plugins/twitter/TwitterUtils.java
@@ -1,0 +1,44 @@
+package com.xatkit.plugins.twitter;
+
+
+import com.xatkit.core.XatkitCore;
+import com.xatkit.plugins.chat.ChatUtils;
+import com.xatkit.plugins.twitter.platform.TwitterPlatform;
+import org.apache.commons.configuration2.Configuration;
+
+/**
+ * An utility interface that holds Twitter-related helpers.
+ * <p>
+ * This class defines the xatkit configuration keys to store the Twitter app API token and consumer.
+ */
+public interface TwitterUtils extends ChatUtils {
+
+    /**
+     * The {@link Configuration} key to store the Twitter app API token.
+     *
+     * @see TwitterPlatform#TwitterPlatform(XatkitCore, Configuration)
+     */
+    String TWITTER_ACCESS_TOKEN_KEY = "xatkit.twitter.accessToken";
+
+    /**
+     * The {@link Configuration} key to store the Twitter app API secret token.
+     *
+     * @see TwitterPlatform#TwitterPlatform(XatkitCore, Configuration)
+     */
+    String TWITTER_ACCESS_SECRET_TOKEN_KEY = "xatkit.twitter.accessSecretToken";
+
+    /**
+     * The {@link Configuration} key to store the Twitter app API consumer.
+     *
+     * @see TwitterPlatform#TwitterPlatform(XatkitCore, Configuration)
+     */
+    String TWITTER_CONSUMER_KEY = "xatkit.twitter.consumerKey";
+
+    /**
+     * The {@link Configuration} key to store the Twitter app API consumer secret.
+     *
+     * @see TwitterPlatform#TwitterPlatform(XatkitCore, Configuration)
+     */
+    String TWITTER_CONSUMER_SECRET = "xatkit.twitter.consumerSecret";
+    
+}

--- a/runtime/src/main/java/com/xatkit/plugins/twitter/TwitterUtils.java
+++ b/runtime/src/main/java/com/xatkit/plugins/twitter/TwitterUtils.java
@@ -7,37 +7,36 @@ import org.apache.commons.configuration2.Configuration;
 /**
  * An utility interface that holds Twitter-related helpers.
  * <p>
- * This class defines the xatkit configuration keys to store the Twitter app API
- * token and consumer.
+ * This class defines the xatkit configuration keys to store the Twitter app API token and consumer.
  */
 public interface TwitterUtils {
 
-	/**
-	 * The {@link Configuration} key to store the Twitter app API token.
-	 *
-	 * @see TwitterPlatform#TwitterPlatform(XatkitCore, Configuration)
-	 */
-	String TWITTER_ACCESS_TOKEN_KEY = "xatkit.twitter.accessToken";
+    /**
+     * The {@link Configuration} key to store the Twitter app API token.
+     *
+     * @see TwitterPlatform#TwitterPlatform(XatkitCore, Configuration)
+     */
+    String TWITTER_ACCESS_TOKEN_KEY = "xatkit.twitter.accessToken";
 
-	/**
-	 * The {@link Configuration} key to store the Twitter app API secret token.
-	 *
-	 * @see TwitterPlatform#TwitterPlatform(XatkitCore, Configuration)
-	 */
-	String TWITTER_ACCESS_SECRET_TOKEN_KEY = "xatkit.twitter.accessSecretToken";
+    /**
+     * The {@link Configuration} key to store the Twitter app API secret token.
+     *
+     * @see TwitterPlatform#TwitterPlatform(XatkitCore, Configuration)
+     */
+    String TWITTER_ACCESS_SECRET_TOKEN_KEY = "xatkit.twitter.accessSecretToken";
 
-	/**
-	 * The {@link Configuration} key to store the Twitter app API consumer.
-	 *
-	 * @see TwitterPlatform#TwitterPlatform(XatkitCore, Configuration)
-	 */
-	String TWITTER_CONSUMER_KEY = "xatkit.twitter.consumerKey";
+    /**
+     * The {@link Configuration} key to store the Twitter app API consumer.
+     *
+     * @see TwitterPlatform#TwitterPlatform(XatkitCore, Configuration)
+     */
+    String TWITTER_CONSUMER_KEY = "xatkit.twitter.consumerKey";
 
-	/**
-	 * The {@link Configuration} key to store the Twitter app API consumer secret.
-	 *
-	 * @see TwitterPlatform#TwitterPlatform(XatkitCore, Configuration)
-	 */
-	String TWITTER_CONSUMER_SECRET = "xatkit.twitter.consumerSecret";
+    /**
+     * The {@link Configuration} key to store the Twitter app API consumer secret.
+     *
+     * @see TwitterPlatform#TwitterPlatform(XatkitCore, Configuration)
+     */
+    String TWITTER_CONSUMER_SECRET = "xatkit.twitter.consumerSecret";
 
 }

--- a/runtime/src/main/java/com/xatkit/plugins/twitter/TwitterUtils.java
+++ b/runtime/src/main/java/com/xatkit/plugins/twitter/TwitterUtils.java
@@ -1,44 +1,43 @@
 package com.xatkit.plugins.twitter;
 
-
 import com.xatkit.core.XatkitCore;
-import com.xatkit.plugins.chat.ChatUtils;
 import com.xatkit.plugins.twitter.platform.TwitterPlatform;
 import org.apache.commons.configuration2.Configuration;
 
 /**
  * An utility interface that holds Twitter-related helpers.
  * <p>
- * This class defines the xatkit configuration keys to store the Twitter app API token and consumer.
+ * This class defines the xatkit configuration keys to store the Twitter app API
+ * token and consumer.
  */
-public interface TwitterUtils extends ChatUtils {
+public interface TwitterUtils {
 
-    /**
-     * The {@link Configuration} key to store the Twitter app API token.
-     *
-     * @see TwitterPlatform#TwitterPlatform(XatkitCore, Configuration)
-     */
-    String TWITTER_ACCESS_TOKEN_KEY = "xatkit.twitter.accessToken";
+	/**
+	 * The {@link Configuration} key to store the Twitter app API token.
+	 *
+	 * @see TwitterPlatform#TwitterPlatform(XatkitCore, Configuration)
+	 */
+	String TWITTER_ACCESS_TOKEN_KEY = "xatkit.twitter.accessToken";
 
-    /**
-     * The {@link Configuration} key to store the Twitter app API secret token.
-     *
-     * @see TwitterPlatform#TwitterPlatform(XatkitCore, Configuration)
-     */
-    String TWITTER_ACCESS_SECRET_TOKEN_KEY = "xatkit.twitter.accessSecretToken";
+	/**
+	 * The {@link Configuration} key to store the Twitter app API secret token.
+	 *
+	 * @see TwitterPlatform#TwitterPlatform(XatkitCore, Configuration)
+	 */
+	String TWITTER_ACCESS_SECRET_TOKEN_KEY = "xatkit.twitter.accessSecretToken";
 
-    /**
-     * The {@link Configuration} key to store the Twitter app API consumer.
-     *
-     * @see TwitterPlatform#TwitterPlatform(XatkitCore, Configuration)
-     */
-    String TWITTER_CONSUMER_KEY = "xatkit.twitter.consumerKey";
+	/**
+	 * The {@link Configuration} key to store the Twitter app API consumer.
+	 *
+	 * @see TwitterPlatform#TwitterPlatform(XatkitCore, Configuration)
+	 */
+	String TWITTER_CONSUMER_KEY = "xatkit.twitter.consumerKey";
 
-    /**
-     * The {@link Configuration} key to store the Twitter app API consumer secret.
-     *
-     * @see TwitterPlatform#TwitterPlatform(XatkitCore, Configuration)
-     */
-    String TWITTER_CONSUMER_SECRET = "xatkit.twitter.consumerSecret";
-    
+	/**
+	 * The {@link Configuration} key to store the Twitter app API consumer secret.
+	 *
+	 * @see TwitterPlatform#TwitterPlatform(XatkitCore, Configuration)
+	 */
+	String TWITTER_CONSUMER_SECRET = "xatkit.twitter.consumerSecret";
+
 }

--- a/runtime/src/main/java/com/xatkit/plugins/twitter/platform/TwitterPlatform.java
+++ b/runtime/src/main/java/com/xatkit/plugins/twitter/platform/TwitterPlatform.java
@@ -5,6 +5,7 @@ import com.xatkit.core.platform.RuntimePlatform;
 import com.xatkit.plugins.twitter.platform.action.PostAtweet;
 import com.xatkit.plugins.twitter.platform.action.SendDM;
 import com.xatkit.plugins.twitter.platform.action.ReceiveDM;
+import com.xatkit.plugins.twitter.TwitterUtils;
 import com.xatkit.plugins.twitter.platform.action.LookForTweets;
 
 import org.apache.commons.configuration2.Configuration;
@@ -26,26 +27,16 @@ import twitter4j.auth.AccessToken;
  * </ul>
  */
 public class TwitterPlatform extends RuntimePlatform {
-	/**
-	 * The {@link Configuration} keys used to store the tokens needed to connect to
-	 * Twitter app.
-	 * <p>
-	 * The provided path can be relative or absolute.
-	 */
-	public static final String TWITTER_CONSUMER_KEY = "xatkit.twitter.consumerKey";
-	public static final String TWITTER_CONSUMER_SECRET = "xatkit.twitter.consumerSecret";
-	public static final String TWITTER_ACCESS_TOKEN_KEY = "xatkit.twitter.accessToken";
-	public static final String TWITTER_ACCESS_SECRET_TOKEN_KEY = "xatkit.twitter.accessSecretToken";
 
 	private Twitter twitterService;
 
 	public TwitterPlatform(XatkitCore XatkitCore, Configuration configuration) {
 		super(XatkitCore, configuration);
 		twitterService = TwitterFactory.getSingleton();
-		twitterService.setOAuthConsumer(configuration.getString(TWITTER_CONSUMER_KEY),
-				configuration.getString(TWITTER_CONSUMER_SECRET));
-		AccessToken accessToken = new AccessToken(configuration.getString(TWITTER_ACCESS_TOKEN_KEY),
-				configuration.getString(TWITTER_ACCESS_SECRET_TOKEN_KEY));
+		twitterService.setOAuthConsumer(configuration.getString(TwitterUtils.TWITTER_CONSUMER_KEY),
+				configuration.getString(TwitterUtils.TWITTER_CONSUMER_SECRET));
+		AccessToken accessToken = new AccessToken(configuration.getString(TwitterUtils.TWITTER_ACCESS_TOKEN_KEY),
+				configuration.getString(TwitterUtils.TWITTER_ACCESS_SECRET_TOKEN_KEY));
 		twitterService.setOAuthAccessToken(accessToken);
 	}
 


### PR DESCRIPTION
For now it is only used to detach the properties keys that until now were defined in `TwitterPlatform.java` file. It could also be used in the future to hold any other configuration needed if/when RTM functionality is added to the platform.