### PR TITLE
Add count param

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ The Twitter platform does not define any provider.
 | PostATweet | - `content` (**String**): the content of the tweet to post          | `0` if the tweet has been posted, `1` otherwise   | Integer      | Posts a tweet on behalf of the configured user with the provided `content` |
 | SendDM | - `user` (**String**): the twitter user to send a direct message to<br/>- `text` (**String**): the content of the direct message | `0` if the direct message has been sent, `1` otherwise | Integer | Sends a direct message to the provided `user` with the given `text` |
 | ReceiveDM | - | A list of Slack [Attachments](https://github.com/seratch/jslack) containing the latest direct messages received | [List\<Attachment\>](https://github.com/seratch/jslack) | Retrieves the latest direct messages received by the configured user |
+| ReceiveDM |  - `messagesPerPage` (**Integer**): the number of messages to retrieve per page up to a maximum of 50 | A list of Slack [Attachments](https://github.com/seratch/jslack) containing the latest `messagesPerPage` direct messages received | [List\<Attachment\>](https://github.com/seratch/jslack) | Retrieves the latest `messagesPerPage` direct messages received by the configured user |
 | LookForTweets | - `query` (**String**): the search terms used to retrieve tweets | A list of Slack [Attachments](https://github.com/seratch/jslack) containing the tweets matching the provided `query` | [List\<Attachment\>](https://github.com/seratch/jslack) | Retrieves a series of tweets matching the provided search `query` |
+| LookForTweets | - `query` (**String**): the search terms used to retrieve tweets<br/>- `resultsPerPage` (**Integer**): the number of tweets to retrieve per page up to a maximum of 100  | A list of Slack [Attachments](https://github.com/seratch/jslack) containing the tweets matching the provided `query` | [List\<Attachment\>](https://github.com/seratch/jslack) | Retrieves a series of tweets matching the provided search `query` |
+
 
 ## Options
 

--- a/platform/TwitterPlatform.platform
+++ b/platform/TwitterPlatform.platform
@@ -6,7 +6,9 @@ actions {
 
 	PostAtweet(content)
 	LookForTweets(query)
+	LookForTweets(query, resultsPerPage)
 	SendDM(user,text)
 	ReceiveDM
+	ReceiveDM(messagesPerPage)
 
 }

--- a/platform/TwitterPlatform.xmi
+++ b/platform/TwitterPlatform.xmi
@@ -6,9 +6,16 @@
   <actions name="LookForTweets">
     <parameters key="query"/>
   </actions>
+  <actions name="LookForTweets">
+    <parameters key="query"/>
+    <parameters key="resultsPerPage"/>
+  </actions>
   <actions name="SendDM">
     <parameters key="user"/>
     <parameters key="text"/>
   </actions>
   <actions name="ReceiveDM"/>
+  <actions name="ReceiveDM">
+    <parameters key="messagesPerPage"/>
+  </actions>
 </platform:PlatformDefinition>

--- a/runtime/src/main/java/com/xatkit/plugins/twitter/platform/action/LookForTweets.java
+++ b/runtime/src/main/java/com/xatkit/plugins/twitter/platform/action/LookForTweets.java
@@ -1,5 +1,8 @@
 package com.xatkit.plugins.twitter.platform.action;
 
+import static fr.inria.atlanmod.commons.Preconditions.checkArgument;
+import static java.util.Objects.nonNull;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,7 +18,8 @@ import twitter4j.Twitter;
 import twitter4j.TwitterException;
 
 /**
- * Seaches for tweets with the provided search terms {@code query}.
+ * Searches for tweets with the provided search terms {@code query}.
+ * Right now it can only return the first page of the results obtained.
  * <p>
  * This class relies on the {@link TwitterPlatform}'s to integrate with twitter.
  */
@@ -25,6 +29,12 @@ public class LookForTweets extends RuntimeAction<TwitterPlatform> {
 	 */
 	private String query;
 
+	/**
+	 * The number of tweets to return per page, up to a maximum of 100. 
+	 * Defaults to 15. 
+	 */
+	private Integer resultsPerPage;	
+	
 	/**
 	 * Seach for tweets {@link LookForTweets} action with the provided
 	 * {@code runtimePlatform}, {@code session}, {@code query}.
@@ -36,15 +46,38 @@ public class LookForTweets extends RuntimeAction<TwitterPlatform> {
 	 */
 	public LookForTweets(TwitterPlatform runtimePlatform, XatkitSession session, String query) {
 		super(runtimePlatform, session);
+        checkArgument(nonNull(query) && !query.isEmpty(), "Cannot construct a %s action with the provided query" +
+                " %s, expected a non-null and not empty String", this.getClass().getSimpleName(), query);
 		this.query = query;
+		this.resultsPerPage = 15;
+	}
+	
+	/**
+	 * Seach for tweets {@link LookForTweets} action with the provided
+	 * {@code runtimePlatform}, {@code session}, {@code query}.
+	 *
+	 * @param runtimePlatform the {@link TwitterPlatform} containing the database to
+	 *                        store the created property
+	 * @param session         the {@link XatkitSession} associated to this action
+	 * @param query           the query to search for tweets
+	 * @param resultsPerPage  the number of tweets to return per page
+	 */
+	public LookForTweets(TwitterPlatform runtimePlatform, XatkitSession session, String query, Integer resultsPerPage) {
+		super(runtimePlatform, session);
+        checkArgument(nonNull(query) && !query.isEmpty(), "Cannot construct a %s action with the provided query" +
+                " %s, expected a non-null and not empty String", this.getClass().getSimpleName(), query);
+        checkArgument(nonNull(resultsPerPage) && (resultsPerPage > 0) && (resultsPerPage <= 100), "Cannot construct a %s "
+        		+ "action with the provided resultsPerPage %s, expected a non-null, greater than 0 and less than or equal to 100 integer",
+        		this.getClass().getSimpleName(), resultsPerPage);
+		this.query = query;
+		this.resultsPerPage = resultsPerPage;
 	}
 
 	/**
 	 * <p>
 	 * This action opens a new conection to with twiter and searches for 
-	 * tweets with search terms {@code query} .
+	 * tweets with search terms {@code query} and return {@code resultsPerPage} resultss.
 	 * 
-	 *
 	 * @return 0 if no errors; 1 if errors
 	 */
 	@Override
@@ -58,6 +91,8 @@ public class LookForTweets extends RuntimeAction<TwitterPlatform> {
 		 */
 		try {
 			Query query = new Query(this.query);
+			query.setCount(resultsPerPage);
+			
 			QueryResult queryResult = twitterService.search(query);
 			List<Status> tweetsList = queryResult.getTweets();
 			if (!tweetsList.isEmpty()) {


### PR DESCRIPTION
For actions `LookForTweets` and `RecieveDM` `count` param was added to enable flexible solutions regarding how many results the actions will return.

As of now both actions are limited by the max results per page permitted by Twitter API. Next step will be to add the ability to iterate the results pages so more results can be returned.